### PR TITLE
Disable Analytics collection with Firebase

### DIFF
--- a/PlexPy Remote/src/main/AndroidManifest.xml
+++ b/PlexPy Remote/src/main/AndroidManifest.xml
@@ -23,6 +23,10 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+
+        <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
+        <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
+
         <activity android:name="com.williamcomartin.plexpyremote.ActivityActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
#70 Permanently deactivates Analytics collection and disables collection of the Advertising ID
