### PR TITLE
Fix issue #74 by handle NumberFormatException

### DIFF
--- a/PlexPy Remote/src/main/java/com/williamcomartin/plexpyremote/Models/ActivityModels.java
+++ b/PlexPy Remote/src/main/java/com/williamcomartin/plexpyremote/Models/ActivityModels.java
@@ -301,7 +301,13 @@ public class ActivityModels {
         }
 
         public String get_bandwidth_string() {
-            Integer bw = Integer.valueOf(bandwidth);
+            Integer bw;
+            try {
+                bw = Integer.valueOf(bandwidth);
+            } catch (NumberFormatException e) {
+                bw = 0;
+            }
+
             if(!media_type.equals("photo") && !bw.equals(0)) {
                 if(bw > 1000) {
                     return String.format("%.1f %s", bw / 1000.0, "Mbps");


### PR DESCRIPTION
When streaming from ChromeCast or if there is a stream Error the bandwidth is in a format that cannot be parsed by Integer.valueOf(), this is now handled with a Try Catch and just defaulting to zero.