### PR TITLE
Mark player name as sensitive

### DIFF
--- a/lib/features/activity/presentation/widgets/activity_bottom_sheet_details.dart
+++ b/lib/features/activity/presentation/widgets/activity_bottom_sheet_details.dart
@@ -72,7 +72,7 @@ class _ActivityBottomSheetDetailsState extends State<ActivityBottomSheetDetails>
                       _ItemRow(
                         title: LocaleKeys.player_title.tr(),
                         item: Text(
-                          widget.activity.player ?? '',
+                          settingsState.appSettings.maskSensitiveInfo ? LocaleKeys.hidden_message.tr() : widget.activity.player ?? '',
                         ),
                       ),
                       _ItemRow(


### PR DESCRIPTION
## Description

This PR marks the player name as sensitive. In my opinion, this could be considered just as sensitive as username, because the player name (often based on the device name) can contain a person's name, location, etc.

If you disagree, feel free to disregard this PR. 😊

| ![image](https://github.com/user-attachments/assets/0baa9677-4727-4190-ba4a-234e401ee079) |
| - |

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
